### PR TITLE
Group restriction should use full DN for group classes which require.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,13 @@ readTimeout: 500ms
 negotiateTls: strict
 ```
 
-* You can set `groupClassName` to `groupOfNames` and the `groupMembershipAttribute` to `member` to search for group membership using the full userDN.
-* `negotiateTls` can be `NONE`, `ATTEMPT`, or `STRICT`. Where `ATTEMPT` tries to negotiate TLS if possible and `STRICT` fails the entire operation if TLS does not succeed in being established. 
+* Group filtering is done by default using only the username provided. The full DN of the user's account will be used
+if `groupClassName` and `groupMembershipAttribute` are set to either `groupOfNames` and `member` or `groupOfUniqueNames` 
+and `uniqueMember`.
+* `negotiateTls` can be `NONE`, `ATTEMPT`, or `STRICT`. Where `ATTEMPT` tries to negotiate TLS if possible and `STRICT` 
+fails the entire operation if TLS does not succeed in being established. Note that you may see exceptions related to the
+initial TLS negotiation attempt in your logs if negotation fails.
+
 
 CHANGELOG
 ---------


### PR DESCRIPTION
When the group class used for filtering is groupOfUniqueNames, the username used in the filter must be an FDN.  This update leverages the existing code which was already in place when using the UserResourceAuthenticator.

In both cases, this fixes group restrictive authentication agaist groupOfUniqueNames.

Given a group such as:
```
# extended LDIF
#
# LDAPv3
# base <ou=Group,dc=example,dc=org> with scope subtree
# filter: cn=MyGroup
# requesting: ALL
#

# MyGroup, Group, example.org
dn: cn=AVD,ou=Group,dc=example,dc=org
objectClass: groupOfUniqueNames
uniqueMember:
uniqueMember: cn=ajbrown,ou=people,dc=example,dc=org
uniqueMember: cn=foobar,ou=people,dc=example,dc=org
uniqueMember: cn=buzzbar,ou=people,dc=example,dc=org
cn: MyGroup
```

Correct Filter: (after PR)
```
(&(uniqueMember=cn=ajbrown,ou=people,dc=example,dc=org)(|(cn=MyGroup)))
```


Incorrect Filter: (before PR)
```
(&(uniqueMember=ajbrown)(|(cn=MyGroup)))
```